### PR TITLE
change split to explode for PHP 7 compatibility

### DIFF
--- a/classes/fileMoveAndAppend.php
+++ b/classes/fileMoveAndAppend.php
@@ -42,7 +42,7 @@ class fileMoveAndAppend extends \System
 		{
 			foreach($files AS $file)
 			{
-				$tmp = split('"elemID"',$file);
+				$tmp = explode('"elemID"',$file);
 				$file = '{"elemID"'.$tmp[1];
 
 //file_put_contents('check.txt',$file."\n", FILE_APPEND );


### PR DESCRIPTION
split was deprecated and removed in PHP 7: http://php.net/manual/en/function.split.php

There might be other PHP 7 compatibility issues. See https://community.contao.org/de/showthread.php?63037-multifileupload-upload-funktioniert-nicht for example.