### PR TITLE
save uploaded file names with delimiter ;

### DIFF
--- a/classes/fileMoveAndAppend.php
+++ b/classes/fileMoveAndAppend.php
@@ -115,7 +115,7 @@ class fileMoveAndAppend extends \System
 									{
 										$subfolder = str_replace(array('/','\\'),'',$GLOBALS['TL_CONFIG']['websitePath']);
 										if( $subfolder != '') $subfolder.= '/';
-										$arrSubmittedArray[$myElemData->name] .= $uploadFolder.'/'.$storeFolderPreFile . $curFile;
+										$arrSubmittedArray[$myElemData->name] .= $uploadFolder.'/'.$storeFolderPreFile . $curFile . ';';
 									}
 								}
 								if($myElemData->sendcase == 'attach')


### PR DESCRIPTION
When the formdata is saved to database, the filepaths/names of the uploaded files are now saved with a delimiter ";". So it is possible to handle multiple Files to use them e.g. in a listing template. 
Simple Example:

```
<?php foreach ($this->tbody as $class=>$row): ?>
<?php $arrImg=explode(';',trim($row['images']['content'],","));?>
<p><?php foreach($arrImg as $img) {echo '<img src="' . $img .'">';}?></p>
<?php endforeach; ?>
```

gives an array of the file-paths which are stored in a table in a field "images".